### PR TITLE
Add an empty lines around the horizontal rule

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -131,7 +131,7 @@ def main():
     for timestamp, md in tweets_markdown:
         dt = datetime.datetime.fromtimestamp(timestamp)
         filename = f'tweets_{dt.year}-{dt.month:02}.md'
-        tweets_by_month[filename] += md + '\n----\n'
+        tweets_by_month[filename] += md + '\n\n----\n'
 
     # Write into files
     for filename, md in tweets_by_month.items():

--- a/parser.py
+++ b/parser.py
@@ -131,7 +131,7 @@ def main():
     for timestamp, md in tweets_markdown:
         dt = datetime.datetime.fromtimestamp(timestamp)
         filename = f'tweets_{dt.year}-{dt.month:02}.md'
-        tweets_by_month[filename] += md + '\n\n----\n'
+        tweets_by_month[filename] += md + '\n\n----\n\n'
 
     # Write into files
     for filename, md in tweets_by_month.items():


### PR DESCRIPTION
A minor thing, but with no empty line before the horizontal rule, the "Originally on Twitter" lines are interpreted as headings.

see: https://www.markdownguide.org/basic-syntax/#horizontal-rule-best-practices